### PR TITLE
add --env-file in addition to --param flag

### DIFF
--- a/commands/marathon/app_cmds.go
+++ b/commands/marathon/app_cmds.go
@@ -179,6 +179,9 @@ func createApp(cmd *cobra.Command, args []string) {
 		cli.Output(nil, errors.New(fmt.Sprintf("%s, consider using the --force flag to update when an application exists", e.Error())))
 		return
 	}
+	if result == nil {
+		return
+	}
 	cli.Output(Application{result}, e)
 }
 


### PR DESCRIPTION
Sorry, PL #12 will print log nil dereference when parameter is absent and ErrorOnMissingParams = false . Small fix. 